### PR TITLE
Add Dalink sponsor link as first custom funding option

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,1 @@
-custom: ['https://boosty.to/0xffff']
+custom: ['https://dalink.to/b4tman1', 'https://boosty.to/0xffff']


### PR DESCRIPTION
### Motivation
- Provide an explicit sponsorship option by adding a Dalink link so it appears first in the project's custom funding options.

### Description
- Update ` .github/FUNDING.yml` to prepend `https://dalink.to/b4tman1` to the `custom` list so it is shown with top priority.

### Testing
- Validated the change with automated checks including `cat .github/FUNDING.yml`, `git status --short`, and `git show --stat --oneline HEAD`, and all checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3e33c11e8832e818e5021b70a91cd)